### PR TITLE
Fix external tenant creation data

### DIFF
--- a/components/onboarding-enhanced/onboarding-enhanced.tsx
+++ b/components/onboarding-enhanced/onboarding-enhanced.tsx
@@ -142,8 +142,20 @@ export default function OnboardingEnhanced({ onComplete, onCancel, editingTenant
 
         // Create tenant account in external API
         await externalApiClient.createTenantAccount({
-          tenant: newTenantData,
-          user: newUserData,
+          tenant: {
+            ...newTenantData,
+            document: newTenantData.document.replace(/\D/g, ""),
+            phone_number: newTenantData.phone_number.replace(/\D/g, ""),
+            address: {
+              ...newAddressData,
+              postal_code: newAddressData.postal_code.replace(/\D/g, ""),
+            },
+          },
+          user: {
+            ...newUserData,
+            password: newUserData.password_hash,
+            document: newUserData.document.replace(/\D/g, ""),
+          },
           gateway: "STRIPE",
         });
         setLogMessages((logs) => [...logs, "Conta criada com sucesso no sistema externo."]);


### PR DESCRIPTION
## Summary
- include address info when creating a tenant in the external API
- send user password field and clean up formatted numbers

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b97450848832e9164a4b9a8fe639f