### PR TITLE
Implement external API token flow

### DIFF
--- a/components/onboarding-enhanced/onboarding-enhanced.tsx
+++ b/components/onboarding-enhanced/onboarding-enhanced.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/lib/database"
 import { getSupabaseClient } from "@/lib/supabase"
 import { ExternalApiClient } from "@/lib/external-api"
+import { setAuthToken as storeAuthToken } from "@/lib/storage"
 
 const supabase = getSupabaseClient()
 
@@ -181,6 +182,9 @@ export default function OnboardingEnhanced({ onComplete, onCancel, editingTenant
         const permanentResp = await externalApiClient.getPermanentToken(tempToken);
         const pipeeloToken = permanentResp.token as string;
         setLogMessages((logs) => [...logs, "Token permanente obtido."]);
+        storeAuthToken(pipeeloToken);
+        setAuthToken(pipeeloToken);
+        externalApiClient.setAuthToken(pipeeloToken);
 
         // Save Address
         const { success: addressSuccess, data: savedAddress, error: addressError } = await saveAddress(newAddressData);
@@ -469,6 +473,7 @@ export default function OnboardingEnhanced({ onComplete, onCancel, editingTenant
               onNext={(data) => handleStepComplete(2, data)}
               onBack={handleBack}
               saving={saving}
+              authToken={authToken}
             />
           )}
 

--- a/components/onboarding-enhanced/step2-api-config.tsx
+++ b/components/onboarding-enhanced/step2-api-config.tsx
@@ -15,9 +15,10 @@ interface Step2Props {
   onNext: (apiConfig: ApiConfiguration) => void
   onBack: () => void
   saving?: boolean
+  authToken?: string | null
 }
 
-export default function Step2ApiConfig({ apiConfig, onNext, onBack, saving = false }: Step2Props) {
+export default function Step2ApiConfig({ apiConfig, onNext, onBack, saving = false, authToken }: Step2Props) {
   const [config, setConfig] = useState<ApiConfiguration>({
     openai_key: apiConfig?.openai_key || "",
     openrouter_key: apiConfig?.openrouter_key || "",
@@ -29,15 +30,15 @@ export default function Step2ApiConfig({ apiConfig, onNext, onBack, saving = fal
     e.preventDefault()
     setIsSaving(true)
 
-    const authToken = getAuthToken()
-    if (!authToken) {
+    const token = authToken || getAuthToken()
+    if (!token) {
       console.error("Authentication token not available.")
       setIsSaving(false)
       return
     }
 
     const apiClient = new ExternalApiClient()
-    apiClient.setAuthToken(authToken)
+    apiClient.setAuthToken(token)
 
     try {
       if (config.openai_key) {

--- a/lib/external-api.ts
+++ b/lib/external-api.ts
@@ -102,6 +102,35 @@ export class ExternalApiClient {
     return response.json();
   }
 
+  async login(email: string, password: string) {
+    const response = await fetch(`${this.baseUrl}/login`, {
+      method: "POST",
+      headers: this.buildHeaders(),
+      body: JSON.stringify({ email, password }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Failed to login: ${response.status} ${response.statusText} - ${errorBody}`);
+    }
+
+    return response.json();
+  }
+
+  async getPermanentToken(token: string) {
+    const response = await fetch(`${this.baseUrl}/permanent-token`, {
+      method: "POST",
+      headers: { ...this.buildHeaders(), Authorization: `Bearer ${token}` },
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Failed to obtain permanent token: ${response.status} ${response.statusText} - ${errorBody}`);
+    }
+
+    return response.json();
+  }
+
   async updateOpenAI(token: string) {
     if (!this.authToken) {
       throw new Error("Authorization token not set");


### PR DESCRIPTION
## Summary
- store Pipeelo token for later steps
- add auth token prop to Step2ApiConfig and use it
- expose login and permanent-token helpers in ExternalApiClient

## Testing
- `pnpm build` *(fails: `next: not found`)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_683c6b36f6c8832ebf1875bfcd8a66c6