### PR TITLE
Update assistant creation for new DB structure

### DIFF
--- a/components/onboarding-enhanced/step7-review-deploy.tsx
+++ b/components/onboarding-enhanced/step7-review-deploy.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import type { Tenant, User, ApiConfiguration, ErpConfiguration, AdvancedConfiguration, Assistant } from "@/types"
+import type { Tenant, User, ApiConfiguration, ErpConfiguration, AdvancedConfiguration, AssistantWithFunctions } from "@/types"
 import { CheckCircle, User as UserIcon, Building2, Key, Settings, MessageSquare, Zap, Bot } from 'lucide-react'
 
 interface Step7Props {
@@ -11,7 +11,7 @@ interface Step7Props {
   adminUser?: User
   apiConfig?: ApiConfiguration
   erpConfig?: ErpConfiguration
-  assistants?: Assistant[] // Added assistants prop
+  assistants?: AssistantWithFunctions[] // Added assistants prop
   advancedConfig?: AdvancedConfiguration
   onDeploy: () => void
   onBack: () => void

--- a/types/index.ts
+++ b/types/index.ts
@@ -144,6 +144,10 @@ export interface Assistant {
   updated_at: string
 }
 
+export interface AssistantWithFunctions extends Assistant {
+  function_ids: string[]
+}
+
 export interface AdvancedConfiguration {
   id: string
   tenant_id: string


### PR DESCRIPTION
## Summary
- add `AssistantWithFunctions` type
- handle prompts and functions in database helper
- save assistant functions during onboarding
- load assistants with function lists for editing

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_683cb7490244832e91526948859ab188