### PR TITLE
Allow global functions without tenant

### DIFF
--- a/components/function-management.tsx
+++ b/components/function-management.tsx
@@ -58,12 +58,6 @@ export default function FunctionManagement({ onBack }: FunctionManagementProps) 
     setLoading(true)
     setError(null)
 
-    if (!tenantId) {
-      setError("Usuário não autenticado")
-      setLoading(false)
-      return
-    }
-
     try {
       const result = await getFunctions(tenantId)
 
@@ -94,10 +88,7 @@ export default function FunctionManagement({ onBack }: FunctionManagementProps) 
   }
 
   const handleCreateFunction = async () => {
-    if (!validateForm() || !tenantId) {
-      if (!tenantId) {
-        setFormErrors({ submit: "Usuário não autenticado" })
-      }
+    if (!validateForm()) {
       return
     }
 
@@ -105,7 +96,7 @@ export default function FunctionManagement({ onBack }: FunctionManagementProps) 
     try {
       const functionData = {
         ...formData,
-        tenant_id: tenantId,
+        tenant_id: tenantId ?? null,
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       } as Function
@@ -140,10 +131,7 @@ export default function FunctionManagement({ onBack }: FunctionManagementProps) 
   }
 
   const handleUpdateFunction = async () => {
-    if (!validateForm() || !tenantId) {
-      if (!tenantId) {
-        setFormErrors({ submit: "Usuário não autenticado" })
-      }
+    if (!validateForm()) {
       return
     }
 
@@ -248,18 +236,7 @@ export default function FunctionManagement({ onBack }: FunctionManagementProps) 
     )
   })
 
-  // Show loading or error if no tenant
-  if (!tenantId) {
-    return (
-      <div className="flex items-center justify-center py-16">
-        <div className="text-center">
-          <p style={{ color: "#718096" }}>
-            Você não está associado a um tenant. Por favor, entre em contato com o suporte.
-          </p>
-        </div>
-      </div>
-    )
-  }
+
 
   return (
     <div className="space-y-6">

--- a/types/index.ts
+++ b/types/index.ts
@@ -124,7 +124,7 @@ export interface Prompt {
 // New Function interface
 export interface Function {
   id: string
-  tenant_id: string
+  tenant_id?: string
   name: string
   description?: string
   schema: Record<string, any> // Using Record<string, any> for JSONB schema


### PR DESCRIPTION
## Summary
- loosen `functions.tenant_id` type to optional
- make `saveFunction` handle null `tenant_id`
- allow `getFunctions` to return global entries when no tenant id is provided
- adjust Function management to work without a tenant

## Testing
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_683cdff37f3c832ebe87a3e6c8563e9b